### PR TITLE
Show 'next month' button when viewing previous month in 'today-past' mode

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -638,11 +638,11 @@ Kalendae.prototype = {
 		} while (++i < c);
 
 		if (opts.directionScrolling) {
-			var diffComparison = moment().startOf('day').hours(12);
+			var diffComparison = moment().startOf('month').hours(12);
 			diff = month.diff(diffComparison, 'months', true);
 
 			if (opts.direction === 'today-past' || opts.direction === 'past') {
-				if (diff <= 0) {
+				if (diff < 0) {
 					this.disableNextMonth = false;
 					util.removeClassName(this.container, classes.disableNextMonth);
 				} else {


### PR DESCRIPTION
In ‘today-past’ or ‘today’ mode:
when ‘today’ is in the middle of the month and
we are looking at last month,
the next month button does not show.

This is because `diffComparison` is anchored to today instead of this
month.  Changing it to the month fixes this bug.
