### PR TITLE
Add missing `var` to definition of `outOfViewMonth` local variable

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -518,7 +518,7 @@ Kalendae.prototype = {
 	},
 
 	makeSelectedDateVisible: function (date) {
-		outOfViewMonth = moment(date).date('1').diff(this.viewStartDate,'months');
+		var outOfViewMonth = moment(date).date('1').diff(this.viewStartDate,'months');
 
 		if(outOfViewMonth < 0){
 			this.viewStartDate.subtract(1,'months');


### PR DESCRIPTION
This codefix helps us avoid some compilation errors we had while compiling our TS & Webpack app which uses Kalendae.