### PR TITLE
Patch yearDay() moment ext to use a UTC date. 

### DIFF
--- a/src/moment.ext.js
+++ b/src/moment.ext.js
@@ -14,7 +14,8 @@ moment = Kalendae.moment;
 
 //function to get the total number of days since the epoch.
 moment.fn.yearDay = function (input) {
-	var yearday = Math.floor(this._d / 86400000);
+	let utcDate = Date.UTC(this._d.getFullYear(), this._d.getMonth(), this._d.getDate());  
+	var yearday = Math.floor(utcDate / 86400000);
     return (typeof input === 'undefined') ? yearday :
         this.add({ d : input - yearday });
 };


### PR DESCRIPTION
To address https://github.com/Twipped/Kalendae/issues/125

In the UK, in late March the clocks go forward 1 hour GMT to BST for what is known as daylight savings. The function yearDay() uses the constant 86400000 for the number of ms in a day, however, March 29th 2020 will have only 82800000ms. This difference causes March 29th to have a yearDay() of 18350 and the 30th to have a yearDay() of 18350.95833333. This being the case, the function isSelected in main.js will indicate both dates as the 'range start' if the 30th is clicked.

Replication: https://jsfiddle.net/sn4a3r6o/2/
Fix: https://jsfiddle.net/sn4a3r6o/3/