### PR TITLE
add 3 more logic checks to see if a parent element was scrolled

### DIFF
--- a/src/util.js
+++ b/src/util.js
@@ -133,7 +133,7 @@ var util = Kalendae.util = {
 		do {
 			var overflow = util.getStyle(elem, 'overflow');
 			// overflow will be either straight up "auto" or it can be "hidden auto" if styles like overflow-x are used
-			if (overflow.indexOf('auto') !== -1 || overflow.indexOf('scroll') !== -1) return elem;
+			if (overflow.indexOf('auto') !== -1 || overflow.indexOf('scroll') !== -1 || elem.scrollLeft > 0 || elem.scrollLeft < 0 || elem.scrollTop > 0) return elem;
 		} while ((elem = elem.parentNode) && elem != window.document.body);
 		return null;
 	},


### PR DESCRIPTION
If a parent element has been scrolled `scrollTop` or `scrollLeft` should be not zero (in the case of right to left languages `scrollLeft` could be negative). 